### PR TITLE
perf(serve): exclude node_modules from livereload

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -27,7 +27,8 @@ module.exports = function (path, openInBrowser, port) {
   server.use(serveStatic(path))
   server.listen(port)
   lrserver.createServer({
-    exts: ['md']
+    exts: ['md'],
+    exclusions: ['node_modules/']
   }).watch(path)
 
   if (openInBrowser) {


### PR DESCRIPTION
Running serve on a project using npm for package management could result
in a high number file watchers. Depending on the contents of
dependancies this could result in node exiting with a ENOSPC error due
to exceeding fs.inotify.max_user_watches.

Resolves issue #16.